### PR TITLE
fix threshold vs split_value in getter

### DIFF
--- a/sklearn_pmml_model/tree/_tree.pyx
+++ b/sklearn_pmml_model/tree/_tree.pyx
@@ -650,7 +650,7 @@ cdef class Tree:
 
     property threshold:
         def __get__(self):
-            return self._get_node_ndarray()['split_value'][:self.node_count]
+            return np.fromstring(self._get_node_ndarray()['split_value'][:self.node_count].tostring(), dtype='float64')
 
     property impurity:
         def __get__(self):

--- a/sklearn_pmml_model/tree/_tree.pyx
+++ b/sklearn_pmml_model/tree/_tree.pyx
@@ -650,7 +650,7 @@ cdef class Tree:
 
     property threshold:
         def __get__(self):
-            return self._get_node_ndarray()['threshold'][:self.node_count]
+            return self._get_node_ndarray()['split_value'][:self.node_count]
 
     property impurity:
         def __get__(self):


### PR DESCRIPTION
Fixes #12. Note that the internal use of `split_value` should probably be removed completely as per sklearn, but that can be a separate PR.