### PR TITLE
Build python wheels using cibuildwheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: python
+
+sudo: false
+
+jobs:
+  include:
+    # perform a linux build
+    - services: docker
+    # and a mac build
+    - os: osx
+      language: shell
+    # and a windows build
+    - os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.8.0
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+
+env:
+  global:
+    - TWINE_USERNAME=__token__
+    - CIBW_SKIP="cp27-* cp33-*"
+    - CIBW_BEFORE_BUILD="python -m pip install cython numpy"
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
+
+install:
+  - python -m pip install twine cibuildwheel==1.1.0
+
+script:
+  # build the wheels, put them into './wheelhouse'
+  - python -m cibuildwheel --output-dir wheelhouse
+
+after_success:
+  # if the release was tagged, upload them to PyPI
+  - if [[ $TRAVIS_TAG ]]; then python -m twine upload wheelhouse/*.whl; fi


### PR DESCRIPTION
To prevent users from having to have Cython installed and having to compile the source code (which proves to be challenging, #4, #8, #10), this PR uses cibuildwheel to automatically build wheels for most manylinux, macOS and windows platforms.