### PR TITLE
define a pyproject.toml (PEP-518)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "Cython==0.29.16", "numpy==1.18.2"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "Cython==0.29.16", "numpy==1.18.2"]
+requires = ["setuptools>=40.8.0", "wheel", "Cython", "numpy>=1.16.0"]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
This patch creates a pyproject.toml and defines the build
dependencies. This allows pip to install the build-time dependencies
in case the user need to compile the native modules when installing.

References:

* PEP-518: https://www.python.org/dev/peps/pep-0518/
* Pip support: https://pip.pypa.io/en/stable/news/#id376