### PR TITLE
Correctly parse priors in naive bayes estimators

### DIFF
--- a/models/nb-cat-pima.pmml
+++ b/models/nb-cat-pima.pmml
@@ -134,11 +134,5 @@
                 </PairCounts>
             </BayesInput>
         </BayesInputs>
-        <BayesOutput fieldName="type">
-            <TargetValueCounts>
-                <TargetValueCount value="No" count="106"/>
-                <TargetValueCount value="Yes" count="106"/>
-            </TargetValueCounts>
-        </BayesOutput>
     </NaiveBayesModel>
 </PMML>

--- a/sklearn_pmml_model/naive_bayes/implementations.py
+++ b/sklearn_pmml_model/naive_bayes/implementations.py
@@ -39,7 +39,13 @@ class PMMLGaussianNB(PMMLBaseClassifier, GaussianNB):
       for target in self.classes_
     }
 
-    self.class_prior_ = np.array([1 / len(self.classes_) for _ in self.classes_])
+    try:
+      outputs = model.find('BayesOutput').find('TargetValueCounts').findall('TargetValueCount')
+      counts = [int(x.get('count')) for x in outputs]
+      self.class_prior_ = np.array([x / np.sum(counts) for x in counts])
+    except AttributeError:
+      self.class_prior_ = np.array([1 / len(self.classes_) for _ in self.classes_])
+
     self.theta_ = np.array([
       [float(value.get('mean', 0)) for value in target_values[target]]
       for target in self.classes_


### PR DESCRIPTION
The prior probabilities in Naive Bayes estimators was ignored and assumed to be uniform (1/n classes). This fix ensures the correct priors are parsed, and will assume a uniform distribution in absence of a `BayesOutput` element.