### PR TITLE
Ensure to parse derived fields from all `LocalTransformations`

### DIFF
--- a/sklearn_pmml_model/base.py
+++ b/sklearn_pmml_model/base.py
@@ -88,9 +88,12 @@ class PMMLBaseEstimator(BaseEstimator):
     """
     data_dictionary = self.root.find('DataDictionary')
     global_transforms = self.root.find('TransformationDictionary')
-    local_transforms = self.root.find('.//LocalTransformations')
+    local_transforms = self.root.findall('.//LocalTransformations')
 
-    derived_fields = findall(global_transforms, 'DerivedField') + findall(local_transforms, 'DerivedField')
+    local_derived_fields = [findall(x, 'DerivedField') for x in local_transforms]
+    local_derived_fields = [field for sublist in local_derived_fields for field in sublist]
+
+    derived_fields = findall(global_transforms, 'DerivedField') + local_derived_fields
 
     fields = OrderedDict({
       e.get('name'): e


### PR DESCRIPTION
Ensemble models may contain multiple `LocalTransformations` element (e.g., in each `Segment`). Those will _all_ need to be parsed if we want to know about all the fields and possible transformations in advance. This caused a sporadic crash for certain gradient boosting models.