### PR TITLE
Support Support Vector Machine models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ This library is in beta, and currently not all models are supported. The library
 ---
 
 The following part of the [specification](http://dmg.org/pmml/v4-3/GeneralStructure.html) is covered:
+- Array (including typed variants)
+- SparseArray *(including typed variants)*
+  - Indices
+  - Entries *(including typed variants)*
 - DataDictionary
-  - DataField (continuous, categorical, ordinal)
+  - DataField *(continuous, categorical, ordinal)*
     - Value
     - Interval
 - TransformationDictionary / LocalTransformations

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This library is in beta, and currently not all models are supported. The library
 | [Lasso](sklearn_pmml_model/linear_model)               | ✅<sup>2</sup> | ✅         | ✅<sup>3</sup>        |
 | [ElasticNet](sklearn_pmml_model/linear_model)          | ✅<sup>2</sup> | ✅         | ✅                    |
 | [Gaussian Naive Bayes](sklearn_pmml_model/naive_bayes) | ✅             |            | ✅<sup>3</sup>        |
+| [Support Vector Machines](sklearn_pmml_model/svm)      | ✅             | ✅         | ✅<sup>3</sup>        |
 
 <sub><sup>1</sup> Categorical feature support using slightly modified internals, based on [scikit-learn#12866](https://github.com/scikit-learn/scikit-learn/pull/12866).</sub>
 
@@ -73,6 +74,19 @@ The following part of the [specification](http://dmg.org/pmml/v4-3/GeneralStruct
       - PairCounts
         - TargetValueCounts
           - TargetValueCount
+- SupportVectorMachineModel
+  - LinearKernelType
+  - PolynomialKernelType
+  - RadialBasisKernelType
+  - SigmoidKernelType
+  - VectorDictionary
+    - VectorFields
+    - VectorInstance
+  - SupportVectorMachine
+    - SupportVectors
+      - SupportVector
+    - Coefficients
+      - Coefficient 
   
 ## Example
 A minimal working example is shown below:

--- a/models/svc-cat-pima.pmml
+++ b/models/svc-cat-pima.pmml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PMML xmlns="http://www.dmg.org/PMML-4_4" xmlns:data="http://jpmml.org/jpmml-model/InlineTable" version="4.4">
+	<Header>
+		<Application name="JPMML-R" version="1.4.4"/>
+		<Timestamp>2021-07-22T11:20:48Z</Timestamp>
+	</Header>
+	<DataDictionary>
+		<DataField name="type" optype="categorical" dataType="string">
+			<Value value="No"/>
+			<Value value="Yes"/>
+		</DataField>
+		<DataField name="npreg" optype="continuous" dataType="double"/>
+		<DataField name="glu" optype="continuous" dataType="double"/>
+		<DataField name="bp" optype="continuous" dataType="double"/>
+		<DataField name="skin" optype="continuous" dataType="double"/>
+		<DataField name="bmi" optype="continuous" dataType="double"/>
+		<DataField name="ped" optype="continuous" dataType="double"/>
+		<DataField name="age" optype="categorical" dataType="string">
+			<Value value="(20,30]"/>
+			<Value value="(30,40]"/>
+			<Value value="(40,50]"/>
+			<Value value="(50,60]"/>
+			<Value value="(60,70]"/>
+		</DataField>
+	</DataDictionary>
+	<TransformationDictionary/>
+	<SupportVectorMachineModel functionName="classification" classificationMethod="OneAgainstOne">
+		<MiningSchema>
+			<MiningField name="type" usageType="target"/>
+			<MiningField name="age"/>
+			<MiningField name="npreg"/>
+			<MiningField name="glu"/>
+			<MiningField name="bp"/>
+			<MiningField name="skin"/>
+			<MiningField name="bmi"/>
+			<MiningField name="ped"/>
+		</MiningSchema>
+		<LocalTransformations>
+			<DerivedField name="scale(npreg)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="npreg"/>
+						<Constant dataType="double">3.7884615384615383</Constant>
+					</Apply>
+					<Constant dataType="double">3.7747174337126292</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(glu)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="glu"/>
+						<Constant dataType="double">127.6923076923077</Constant>
+					</Apply>
+					<Constant dataType="double">30.590616568175218</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(bp)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="bp"/>
+						<Constant dataType="double">74.68858981173888</Constant>
+					</Apply>
+					<Constant dataType="double">10.513032937113188</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(skin)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="skin"/>
+						<Constant dataType="double">31.482109488578555</Constant>
+					</Apply>
+					<Constant dataType="double">10.51639268163093</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(bmi)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="bmi"/>
+						<Constant dataType="double">34.69397755176341</Constant>
+					</Apply>
+					<Constant dataType="double">6.232781228378887</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(ped)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="ped"/>
+						<Constant dataType="double">0.47128846153846154</Constant>
+					</Apply>
+					<Constant dataType="double">0.3016158663675463</Constant>
+				</Apply>
+			</DerivedField>
+		</LocalTransformations>
+		<RadialBasisKernelType gamma="0.09090909090909091"/>
+		<VectorDictionary>
+			<VectorFields>
+				<FieldRef field="scale(npreg)"/>
+				<FieldRef field="scale(glu)"/>
+				<FieldRef field="scale(bp)"/>
+				<FieldRef field="scale(skin)"/>
+				<FieldRef field="scale(bmi)"/>
+				<FieldRef field="scale(ped)"/>
+				<CategoricalPredictor name="age" value="(20,30]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(30,40]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(40,50]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(50,60]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(60,70]" coefficient="1.0"/>
+			</VectorFields>
+			<VectorInstance id="1">
+				<Array type="real">-0.47380011083438744 0.0100583885586802 0.3149814338135626 0.5246942253363732 1.3807676112634821 2.495596626021958 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="2">
+				<Array type="real">2.175404809960037 -1.1667730728069075 -1.206939033449189 -2.327994991223717 -1.1381720762896912 1.5075849421907774 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="7">
+				<Array type="real">0.32096136540393994 0.36964577953149863 0.5052214922214066 0.3345149442323672 -0.496404003027736 -0.36565868654954997 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="9">
+				<Array type="real">-0.7387206029138299 -0.4149085280455598 -0.4459787998178132 -0.1409332585276478 -0.015077948081269651 0.19134118889890142 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="12">
+				<Array type="real">-0.20887961875494498 0.04274815137439097 1.6466618426684703 1.6657699119604092 0.2737176848866097 1.64683491105289 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="13">
+				<Array type="real">-1.0036410949932724 2.298341785658434 -0.8264589166335011 0.049246022576358225 1.0598835746325046 0.10182335177325738 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="14">
+				<Array type="real">-1.0036410949932724 1.9714441575013264 0.6954615506292504 -1.6623675073596957 -0.4322271957015407 0.6986089326108839 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="15">
+				<Array type="real">-0.20887961875494498 0.9907512730300032 0.12474137540571863 0.42960458478437025 -0.496404003027736 1.2589242835084329 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="16">
+				<Array type="real">-1.0036410949932724 0.7619229333200279 1.4564217842606262 1.3805009903044003 1.1882371892848962 -0.3325039320585707 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="17">
+				<Array type="real">-1.0036410949932724 -1.068703784359775 0.9808216382410163 -0.6163814612876628 0.4341597032020985 -0.7436228877467133 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="18">
+				<Array type="real">2.7052457941189223 1.5464772408970864 -1.206939033449189 -0.1409332585276478 -0.17551996639675843 -0.8596645284651405 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="19">
+				<Array type="real">0.8508023495628249 0.04274815137439097 -0.6362188582256572 1.6657699119604092 0.6106459233491364 -0.10705160151991185 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="20">
+				<Array type="real">1.1157228416422673 0.892681984582871 -1.206939033449189 -0.5212918207356598 -0.11134315907056315 0.2377578451862724 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="22">
+				<Array type="real">1.1157228416422673 -0.08801089988845211 2.027141959484158 0.22372578857205253 0.01489786606199215 -0.7933550194831821 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="23">
+				<Array type="real">-0.47380011083438744 -0.31683923959842747 0.5052214922214066 -0.07891157559922476 1.316590803937287 0.7350791625509607 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="24">
+				<Array type="real">1.1157228416422673 0.17350720263723404 -0.2557387414099693 0.11336682344895582 -0.28782937921760104 -0.667366952417461 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="25">
+				<Array type="real">-1.0036410949932724 0.4350253051629202 0.13682302113358621 0.38335895637305323 1.2363697947795425 -0.8828728566088261 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="26">
+				<Array type="real">-0.20887961875494498 0.4350253051629202 -0.2407884106009078 -0.06409135627114358 -0.7531112323325183 0.9605314930896198 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="27">
+				<Array type="real">-1.0036410949932724 1.2195796127399787 0.12474137540571863 1.0952320686483912 2.1188008955147306 -0.7038371823575382 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="30">
+				<Array type="real">-0.47380011083438744 -0.5783573421241136 -0.06549868300212532 -0.2360228990796508 -0.3680503883753454 0.7516565397964504 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="31">
+				<Array type="real">-0.20887961875494498 0.6638536448728956 -0.8264589166335011 -0.6163814612876628 -0.35200618654379634 -0.7137836087048319 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="33">
+				<Array type="real">-1.0036410949932724 -0.28414947678271674 -0.8264589166335011 -0.4262021801836568 0.6587785288437825 -0.7038371823575382 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="34">
+				<Array type="real">-0.7387206029138299 -1.0033242587283537 -0.6362188582256572 -0.9967400234956748 -1.202348883615887 2.0679002930883263 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="36">
+				<Array type="real">-0.47380011083438744 -0.08801089988845211 -1.3971790918570328 -1.091829664047678 -0.14343156273366137 -1.2707834841532832 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="37">
+				<Array type="real">-0.7387206029138299 -0.44759829086127056 -0.8264589166335011 0.42960458478437025 0.5464691160229411 -0.6043729188846005 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="38">
+				<Array type="real">0.5858818574833824 -1.1667730728069075 -1.206939033449189 0.049246022576358225 -0.4322271957015407 -1.280729910500577 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="39">
+				<Array type="real">-1.0036410949932724 0.2388867282686556 1.8369019010763141 1.3805009903044003 0.9475741618116631 -0.6209502961300902 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="40">
+				<Array type="real">-0.47380011083438744 -0.2187699511512952 -0.4459787998178132 0.049246022576358225 0.7069111343384299 1.3749659242268604 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="41">
+				<Array type="real">2.175404809960037 -0.2187699511512952 0.3149814338135626 -1.3770985857036868 -1.314658296436729 -0.7038371823575382 0.0 0.0 0.0 0.0 1.0</Array>
+			</VectorInstance>
+			<VectorInstance id="43">
+				<Array type="real">-0.20887961875494498 -2.1801557200939414 0.6954615506292504 -0.33111253963165377 -0.04716635174436787 -0.756884789543105 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="44">
+				<Array type="real">0.5858818574833824 -0.5456675793084028 -1.016698975041345 0.7148735064403793 -0.07925475540746493 -0.7005217069084403 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="45">
+				<Array type="real">-0.7387206029138299 -1.526360463779726 -0.06549868300212532 0.9050527875443852 1.8620936662099483 2.0712157685374244 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="46">
+				<Array type="real">-1.0036410949932724 0.3042662539000771 0.8857016090370944 -0.4262021801836568 -1.186304681784338 -0.79667049493228 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="49">
+				<Array type="real">-1.0036410949932724 -0.9052549702812214 1.2661817258527823 2.7117559580324424 1.9423146753676928 1.6269420583583023 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="51">
+				<Array type="real">-0.20887961875494498 -0.12070066270416287 0.5052214922214066 0.1443356631283612 -0.23969677372295373 -0.5513253116990338 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="52">
+				<Array type="real">0.32096136540393994 0.36964577953149863 -1.016698975041345 0.3345149442323672 -0.9777300579742023 -0.1998849140946538 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+		</VectorDictionary>
+		<SupportVectorMachine targetCategory="No" alternateTargetCategory="Yes">
+			<SupportVectors>
+				<SupportVector vectorId="1"/>
+				<SupportVector vectorId="2"/>
+				<SupportVector vectorId="7"/>
+				<SupportVector vectorId="9"/>
+				<SupportVector vectorId="12"/>
+				<SupportVector vectorId="13"/>
+				<SupportVector vectorId="14"/>
+				<SupportVector vectorId="15"/>
+				<SupportVector vectorId="16"/>
+				<SupportVector vectorId="17"/>
+				<SupportVector vectorId="18"/>
+				<SupportVector vectorId="19"/>
+				<SupportVector vectorId="20"/>
+				<SupportVector vectorId="22"/>
+				<SupportVector vectorId="23"/>
+				<SupportVector vectorId="24"/>
+				<SupportVector vectorId="25"/>
+				<SupportVector vectorId="26"/>
+				<SupportVector vectorId="27"/>
+				<SupportVector vectorId="30"/>
+				<SupportVector vectorId="31"/>
+				<SupportVector vectorId="33"/>
+				<SupportVector vectorId="34"/>
+				<SupportVector vectorId="36"/>
+				<SupportVector vectorId="37"/>
+				<SupportVector vectorId="38"/>
+				<SupportVector vectorId="39"/>
+				<SupportVector vectorId="40"/>
+				<SupportVector vectorId="41"/>
+				<SupportVector vectorId="43"/>
+				<SupportVector vectorId="44"/>
+				<SupportVector vectorId="45"/>
+				<SupportVector vectorId="46"/>
+				<SupportVector vectorId="49"/>
+				<SupportVector vectorId="51"/>
+				<SupportVector vectorId="52"/>
+			</SupportVectors>
+			<Coefficients absoluteValue="-0.050320746562785366">
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-0.5644464780552596"/>
+				<Coefficient value="-0.8200625306356393"/>
+				<Coefficient value="-0.7295267913726711"/>
+				<Coefficient value="-0.39963111744411345"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-0.41240221176283304"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-0.9978584268568605"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="0.5986629800653184"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="0.817336947438522"/>
+				<Coefficient value="0.3880321541690222"/>
+				<Coefficient value="0.11989547445451426"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+			</Coefficients>
+		</SupportVectorMachine>
+	</SupportVectorMachineModel>
+</PMML>

--- a/models/svr-cat-pima.pmml
+++ b/models/svr-cat-pima.pmml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PMML xmlns="http://www.dmg.org/PMML-4_4" xmlns:data="http://jpmml.org/jpmml-model/InlineTable" version="4.4">
+	<Header>
+		<Application name="JPMML-R" version="1.4.4"/>
+		<Timestamp>2021-07-20T20:38:39Z</Timestamp>
+	</Header>
+	<DataDictionary>
+		<DataField name="type" optype="continuous" dataType="double"/>
+		<DataField name="npreg" optype="continuous" dataType="double"/>
+		<DataField name="glu" optype="continuous" dataType="double"/>
+		<DataField name="bp" optype="continuous" dataType="double"/>
+		<DataField name="skin" optype="continuous" dataType="double"/>
+		<DataField name="bmi" optype="continuous" dataType="double"/>
+		<DataField name="ped" optype="continuous" dataType="double"/>
+		<DataField name="age" optype="categorical" dataType="string">
+			<Value value="(20,30]"/>
+			<Value value="(30,40]"/>
+			<Value value="(40,50]"/>
+			<Value value="(50,60]"/>
+			<Value value="(60,70]"/>
+		</DataField>
+	</DataDictionary>
+	<TransformationDictionary/>
+	<SupportVectorMachineModel functionName="regression">
+		<MiningSchema>
+			<MiningField name="type" usageType="target"/>
+			<MiningField name="age"/>
+			<MiningField name="npreg"/>
+			<MiningField name="glu"/>
+			<MiningField name="bp"/>
+			<MiningField name="skin"/>
+			<MiningField name="bmi"/>
+			<MiningField name="ped"/>
+		</MiningSchema>
+		<Targets>
+			<Target field="type" rescaleConstant="0.5" rescaleFactor="-0.5048781642974013"/>
+		</Targets>
+		<LocalTransformations>
+			<DerivedField name="scale(npreg)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="npreg"/>
+						<Constant dataType="double">3.7884615384615383</Constant>
+					</Apply>
+					<Constant dataType="double">3.7747174337126292</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(glu)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="glu"/>
+						<Constant dataType="double">127.6923076923077</Constant>
+					</Apply>
+					<Constant dataType="double">30.590616568175218</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(bp)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="bp"/>
+						<Constant dataType="double">74.68858981173888</Constant>
+					</Apply>
+					<Constant dataType="double">10.513032937113188</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(skin)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="skin"/>
+						<Constant dataType="double">31.482109488578555</Constant>
+					</Apply>
+					<Constant dataType="double">10.51639268163093</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(bmi)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="bmi"/>
+						<Constant dataType="double">34.69397755176341</Constant>
+					</Apply>
+					<Constant dataType="double">6.232781228378887</Constant>
+				</Apply>
+			</DerivedField>
+			<DerivedField name="scale(ped)" optype="continuous" dataType="double">
+				<Apply function="/">
+					<Apply function="-">
+						<FieldRef field="ped"/>
+						<Constant dataType="double">0.47128846153846154</Constant>
+					</Apply>
+					<Constant dataType="double">0.3016158663675463</Constant>
+				</Apply>
+			</DerivedField>
+		</LocalTransformations>
+		<RadialBasisKernelType gamma="0.09090909090909091"/>
+		<VectorDictionary>
+			<VectorFields>
+				<FieldRef field="scale(npreg)"/>
+				<FieldRef field="scale(glu)"/>
+				<FieldRef field="scale(bp)"/>
+				<FieldRef field="scale(skin)"/>
+				<FieldRef field="scale(bmi)"/>
+				<FieldRef field="scale(ped)"/>
+				<CategoricalPredictor name="age" value="(20,30]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(30,40]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(40,50]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(50,60]" coefficient="1.0"/>
+				<CategoricalPredictor name="age" value="(60,70]" coefficient="1.0"/>
+			</VectorFields>
+			<VectorInstance id="1">
+				<Array type="real">-0.47380011083438744 0.0100583885586802 0.3149814338135626 0.5246942253363732 1.3807676112634821 2.495596626021958 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="2">
+				<Array type="real">2.175404809960037 -1.1667730728069075 -1.206939033449189 -2.327994991223717 -1.1381720762896912 1.5075849421907774 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="3">
+				<Array type="real">1.9104843178805948 0.5004048307943417 1.8369019010763141 0.1443356631283612 0.3058060885497079 -0.7204145596030278 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="4">
+				<Array type="real">1.3806433337217099 1.186889849924268 0.8857016090370944 -0.9967400234956748 -0.6247576176801272 1.1926147745264744 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="5">
+				<Array type="real">1.1157228416422673 1.5791670037127972 1.4564217842606262 0.23942530368036422 -0.15947576456520932 -0.014218288945169879 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="7">
+				<Array type="real">0.32096136540393994 0.36964577953149863 0.5052214922214066 0.3345149442323672 -0.496404003027736 -0.36565868654954997 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="9">
+				<Array type="real">-0.7387206029138299 -0.4149085280455598 -0.4459787998178132 -0.1409332585276478 -0.015077948081269651 0.19134118889890142 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="11">
+				<Array type="real">1.6455638258011522 0.6638536448728956 0.8857016090370944 1.5706802714084063 0.4662481068651967 1.756245600873121 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="12">
+				<Array type="real">-0.20887961875494498 0.04274815137439097 1.6466618426684703 1.6657699119604092 0.2737176848866097 1.64683491105289 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="13">
+				<Array type="real">-1.0036410949932724 2.298341785658434 -0.8264589166335011 0.049246022576358225 1.0598835746325046 0.10182335177325738 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="14">
+				<Array type="real">-1.0036410949932724 1.9714441575013264 0.6954615506292504 -1.6623675073596957 -0.4322271957015407 0.6986089326108839 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="15">
+				<Array type="real">-0.20887961875494498 0.9907512730300032 0.12474137540571863 0.42960458478437025 -0.496404003027736 1.2589242835084329 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="16">
+				<Array type="real">-1.0036410949932724 0.7619229333200279 1.4564217842606262 1.3805009903044003 1.1882371892848962 -0.3325039320585707 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="17">
+				<Array type="real">-1.0036410949932724 -1.068703784359775 0.9808216382410163 -0.6163814612876628 0.4341597032020985 -0.7436228877467133 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="18">
+				<Array type="real">2.7052457941189223 1.5464772408970864 -1.206939033449189 -0.1409332585276478 -0.17551996639675843 -0.8596645284651405 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="19">
+				<Array type="real">0.8508023495628249 0.04274815137439097 -0.6362188582256572 1.6657699119604092 0.6106459233491364 -0.10705160151991185 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="20">
+				<Array type="real">1.1157228416422673 0.892681984582871 -1.206939033449189 -0.5212918207356598 -0.11134315907056315 0.2377578451862724 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="22">
+				<Array type="real">1.1157228416422673 -0.08801089988845211 2.027141959484158 0.22372578857205253 0.01489786606199215 -0.7933550194831821 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="23">
+				<Array type="real">-0.47380011083438744 -0.31683923959842747 0.5052214922214066 -0.07891157559922476 1.316590803937287 0.7350791625509607 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="24">
+				<Array type="real">1.1157228416422673 0.17350720263723404 -0.2557387414099693 0.11336682344895582 -0.28782937921760104 -0.667366952417461 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="25">
+				<Array type="real">-1.0036410949932724 0.4350253051629202 0.13682302113358621 0.38335895637305323 1.2363697947795425 -0.8828728566088261 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="26">
+				<Array type="real">-0.20887961875494498 0.4350253051629202 -0.2407884106009078 -0.06409135627114358 -0.7531112323325183 0.9605314930896198 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="27">
+				<Array type="real">-1.0036410949932724 1.2195796127399787 0.12474137540571863 1.0952320686483912 2.1188008955147306 -0.7038371823575382 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="29">
+				<Array type="real">-0.47380011083438744 -0.937944733096932 -0.4459787998178132 -1.4721882262556898 -2.2933546081612106 -0.7834085931358884 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="30">
+				<Array type="real">-0.47380011083438744 -0.5783573421241136 -0.06549868300212532 -0.2360228990796508 -0.3680503883753454 0.7516565397964504 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="31">
+				<Array type="real">-0.20887961875494498 0.6638536448728956 -0.8264589166335011 -0.6163814612876628 -0.35200618654379634 -0.7137836087048319 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="32">
+				<Array type="real">-0.7387206029138299 -1.8532580919368336 -2.5386194423040966 -1.2820089451516838 -2.2933546081612106 -0.491646753615271 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="33">
+				<Array type="real">-1.0036410949932724 -0.28414947678271674 -0.8264589166335011 -0.4262021801836568 0.6587785288437825 -0.7038371823575382 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="34">
+				<Array type="real">-0.7387206029138299 -1.0033242587283537 -0.6362188582256572 -0.9967400234956748 -1.202348883615887 2.0679002930883263 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="35">
+				<Array type="real">-1.0036410949932724 -1.3629116497011722 -0.6362188582256572 0.049246022576358225 0.1774524738973162 -0.7734621667885947 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="36">
+				<Array type="real">-0.47380011083438744 -0.08801089988845211 -1.3971790918570328 -1.091829664047678 -0.14343156273366137 -1.2707834841532832 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="37">
+				<Array type="real">-0.7387206029138299 -0.44759829086127056 -0.8264589166335011 0.42960458478437025 0.5464691160229411 -0.6043729188846005 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="38">
+				<Array type="real">0.5858818574833824 -1.1667730728069075 -1.206939033449189 0.049246022576358225 -0.4322271957015407 -1.280729910500577 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="39">
+				<Array type="real">-1.0036410949932724 0.2388867282686556 1.8369019010763141 1.3805009903044003 0.9475741618116631 -0.6209502961300902 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="40">
+				<Array type="real">-0.47380011083438744 -0.2187699511512952 -0.4459787998178132 0.049246022576358225 0.7069111343384299 1.3749659242268604 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="41">
+				<Array type="real">2.175404809960037 -0.2187699511512952 0.3149814338135626 -1.3770985857036868 -1.314658296436729 -0.7038371823575382 0.0 0.0 0.0 0.0 1.0</Array>
+			</VectorInstance>
+			<VectorInstance id="43">
+				<Array type="real">-0.20887961875494498 -2.1801557200939414 0.6954615506292504 -0.33111253963165377 -0.04716635174436787 -0.756884789543105 0.0 0.0 1.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="44">
+				<Array type="real">0.5858818574833824 -0.5456675793084028 -1.016698975041345 0.7148735064403793 -0.07925475540746493 -0.7005217069084403 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="45">
+				<Array type="real">-0.7387206029138299 -1.526360463779726 -0.06549868300212532 0.9050527875443852 1.8620936662099483 2.0712157685374244 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="46">
+				<Array type="real">-1.0036410949932724 0.3042662539000771 0.8857016090370944 -0.4262021801836568 -1.186304681784338 -0.79667049493228 0.0 0.0 0.0 1.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="47">
+				<Array type="real">-0.7387206029138299 -1.0033242587283537 -0.4459787998178132 0.8099631469923823 0.5464691160229411 -0.839771675770553 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="48">
+				<Array type="real">-0.47380011083438744 -0.7418061562026674 -1.587419150264877 0.8099631469923823 0.03305465741337653 -0.8165633476268676 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="49">
+				<Array type="real">-1.0036410949932724 -0.9052549702812214 1.2661817258527823 2.7117559580324424 1.9423146753676928 1.6269420583583023 0.0 1.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="50">
+				<Array type="real">-0.7387206029138299 -1.232152598438329 -1.206939033449189 -1.852546788463702 -1.202348883615887 0.3604304368028953 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="51">
+				<Array type="real">-0.20887961875494498 -0.12070066270416287 0.5052214922214066 0.1443356631283612 -0.23969677372295373 -0.5513253116990338 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+			<VectorInstance id="52">
+				<Array type="real">0.32096136540393994 0.36964577953149863 -1.016698975041345 0.3345149442323672 -0.9777300579742023 -0.1998849140946538 1.0 0.0 0.0 0.0 0.0</Array>
+			</VectorInstance>
+		</VectorDictionary>
+		<SupportVectorMachine>
+			<SupportVectors>
+				<SupportVector vectorId="1"/>
+				<SupportVector vectorId="2"/>
+				<SupportVector vectorId="3"/>
+				<SupportVector vectorId="4"/>
+				<SupportVector vectorId="5"/>
+				<SupportVector vectorId="7"/>
+				<SupportVector vectorId="9"/>
+				<SupportVector vectorId="11"/>
+				<SupportVector vectorId="12"/>
+				<SupportVector vectorId="13"/>
+				<SupportVector vectorId="14"/>
+				<SupportVector vectorId="15"/>
+				<SupportVector vectorId="16"/>
+				<SupportVector vectorId="17"/>
+				<SupportVector vectorId="18"/>
+				<SupportVector vectorId="19"/>
+				<SupportVector vectorId="20"/>
+				<SupportVector vectorId="22"/>
+				<SupportVector vectorId="23"/>
+				<SupportVector vectorId="24"/>
+				<SupportVector vectorId="25"/>
+				<SupportVector vectorId="26"/>
+				<SupportVector vectorId="27"/>
+				<SupportVector vectorId="29"/>
+				<SupportVector vectorId="30"/>
+				<SupportVector vectorId="31"/>
+				<SupportVector vectorId="32"/>
+				<SupportVector vectorId="33"/>
+				<SupportVector vectorId="34"/>
+				<SupportVector vectorId="35"/>
+				<SupportVector vectorId="36"/>
+				<SupportVector vectorId="37"/>
+				<SupportVector vectorId="38"/>
+				<SupportVector vectorId="39"/>
+				<SupportVector vectorId="40"/>
+				<SupportVector vectorId="41"/>
+				<SupportVector vectorId="43"/>
+				<SupportVector vectorId="44"/>
+				<SupportVector vectorId="45"/>
+				<SupportVector vectorId="46"/>
+				<SupportVector vectorId="47"/>
+				<SupportVector vectorId="48"/>
+				<SupportVector vectorId="49"/>
+				<SupportVector vectorId="50"/>
+				<SupportVector vectorId="51"/>
+				<SupportVector vectorId="52"/>
+			</SupportVectors>
+			<Coefficients absoluteValue="-0.0553444336226925">
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-0.08632473164833687"/>
+				<Coefficient value="0.24060113783124373"/>
+				<Coefficient value="0.5071360366886227"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="0.08871092201987817"/>
+				<Coefficient value="-0.679855764919319"/>
+				<Coefficient value="-0.9000365172447015"/>
+				<Coefficient value="-0.7588566083229974"/>
+				<Coefficient value="-0.5019362675061958"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-0.5118552469635075"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="-0.3573498542861633"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="0.20412264822683826"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="-1.0"/>
+				<Coefficient value="0.8265460593273236"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="0.4372094518742998"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="0.4287692829748912"/>
+				<Coefficient value="-0.8447128900514442"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="-0.09216765800043228"/>
+				<Coefficient value="1.0"/>
+				<Coefficient value="1.0"/>
+			</Coefficients>
+		</SupportVectorMachine>
+	</SupportVectorMachineModel>
+</PMML>

--- a/sklearn_pmml_model/svm/README.md
+++ b/sklearn_pmml_model/svm/README.md
@@ -1,0 +1,19 @@
+# sklearn-pmml-model.svm
+
+This package contains the `PMMLLinearSVC`, `PMMLNuSVC` and `PMMLSVC` classifier models, as well as the `PMMLLinearSVR`, `PMMLNuSVR` and `PMMLSVR` regression models. 
+
+## Example
+A minimal working example is shown below:
+
+```python
+import pandas as pd
+from sklearn_pmml_model.svm import PMMLSVC
+
+# Prepare data
+df = pd.read_csv('models/categorical-test.csv')
+Xte = df.iloc[:, 1:]
+Xte = pd.get_dummies(Xte, prefix_sep='')  # create categorical variable
+
+clf = PMMLSVC(pmml="models/svc_cat_pima.pmml")
+clf.predict(Xte)
+```

--- a/sklearn_pmml_model/svm/__init__.py
+++ b/sklearn_pmml_model/svm/__init__.py
@@ -1,0 +1,7 @@
+"""
+The :mod:`sklearn.svm` module includes Support Vector Machine algorithms.
+"""
+
+from ._classes import PMMLLinearSVC, PMMLLinearSVR, PMMLNuSVC, PMMLNuSVR, PMMLSVC, PMMLSVR
+
+__all__ = ["PMMLLinearSVC", "PMMLLinearSVR", "PMMLNuSVC", "PMMLNuSVR", "PMMLSVC", "PMMLSVR"]

--- a/sklearn_pmml_model/svm/_base.py
+++ b/sklearn_pmml_model/svm/_base.py
@@ -1,0 +1,96 @@
+from sklearn_pmml_model.base import parse_array
+import numpy as np
+
+
+class PMMLBaseSVM:
+  """
+  Abstract class for Support Vector Machines.
+
+  The PMML model consists out of a <SupportVectorMachineModel> element,
+  containing a <SupportVectorMachine> element that contains a <SupportVectors>
+  element describing support vectors, and a <Coefficients> element describing
+  the coefficients for each support vector. Support vectors are referenced from
+  a <VectorDictionary> element, in which the true support vectors are described
+  using <VectorInstance> elements. Furthermore, the model contains one out of
+  <LinearKernelType>, <PolynomialKernelType>, <RadialBasisKernelType> or
+  <SigmoidKernelType> describing the kernel function used.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/SupportVectorMachineModel.html
+
+  """
+  def __init__(self):
+    # Import coefficients and intercepts
+    model = self.root.find('SupportVectorMachineModel')
+
+    if model is None:
+      raise Exception('PMML model does not contain SupportVectorMachineModel.')
+
+    vector_dictionary = model.find('VectorDictionary')
+    svm = model.find('SupportVectorMachine')
+    support_vectors = svm.find('SupportVectors')
+    coefficients = svm.find('Coefficients')
+
+    self.shape_fit_ = (0, len(vector_dictionary.find('VectorFields')))
+    self._intercept_ = self.intercept_ = np.array([float(coefficients.get('absoluteValue'))])
+    self._dual_coef_ = self.dual_coef_ = np.array([[
+      float(c.get('value'))
+      for c in coefficients.findall("Coefficient")
+    ]])
+    self.support_ = np.array([
+      int(s.get('vectorId'))
+      for s in support_vectors.findall('SupportVector')
+    ]).astype(np.int32)
+    self._n_support = (np.repeat(len(self.support_), self.n_classes_) / self.n_classes_).astype(np.int32)
+    self.support_vectors_ = np.array([get_vectors(vector_dictionary, s) for s in self.support_])
+
+    linear = model.find('LinearKernelType')
+    poly = model.find('PolynomialKernelType')
+    rbf = model.find('RadialBasisKernelType')
+    sigmoid = model.find('SigmoidKernelType')
+
+    if linear is not None:
+      self.kernel = 'linear'
+      self._gamma = self.gamma = 0.0
+    elif poly is not None:
+      self.kernel = 'poly'
+      self._gamma = self.gamma = float(poly.get('gamma'))
+      self.coef0 = float(poly.get('coef0'))
+      self.degree = int(poly.get('degree'))
+    elif rbf is not None:
+      self.kernel = 'rbf'
+      self._gamma = self.gamma = float(rbf.get('gamma'))
+    elif sigmoid is not None:
+      self.kernel = 'sigmoid'
+      self._gamma = self.gamma = float(sigmoid.get('gamma'))
+      self.coef0 = float(sigmoid.get('coef0'))
+    else:
+      raise Exception('Unknown or missing kernel type.')
+
+    self._probA = np.array([])
+    self._probB = np.array([])
+
+
+def get_vectors(vector_dictionary, s):
+  instance = vector_dictionary.find(f"VectorInstance[@id='{s}']")
+
+  if instance is None:
+    raise Exception(f'PMML model is broken, vector instance (id = {s}) not found.')
+
+  array = instance.find('Array')
+  if array is None:
+    array = instance.find('REAL-Array')
+  if array is None:
+    array = instance.find('SparseArray')
+  if array is None:
+    array = instance.find('REAL-SparseArray')
+  if array is None:
+    raise Exception(f'PMML model is broken, vector instance (id = {s}) does not contain (Sparse)Array element.')
+
+  return np.array(parse_array(array))

--- a/sklearn_pmml_model/svm/_classes.py
+++ b/sklearn_pmml_model/svm/_classes.py
@@ -1,0 +1,286 @@
+from sklearn.svm import LinearSVC, LinearSVR, NuSVC, NuSVR, SVC, SVR
+import numpy as np
+from scipy.sparse import isspmatrix
+from sklearn_pmml_model.base import OneHotEncodingMixin, PMMLBaseClassifier, PMMLBaseRegressor
+from sklearn_pmml_model.svm._base import PMMLBaseSVM
+from sklearn_pmml_model.linear_model.implementations import _get_coefficients as _linear_get_coefficients
+
+
+class PMMLLinearSVC(OneHotEncodingMixin, PMMLBaseClassifier, LinearSVC):
+  """
+  Linear Support Vector Classification.
+
+  Similar to SVC with parameter kernel='linear', but implemented in terms of
+  liblinear rather than libsvm, so it has more flexibility in the choice of
+  penalties and loss functions and should scale better to large numbers of
+  samples.
+
+  This class supports both dense and sparse input and the multiclass support
+  is handled according to a one-vs-the-rest scheme.
+
+  The PMML model is assumed to be equivalent to PMMLLogisticRegression.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/Regression.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseClassifier.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+
+    # Import coefficients and intercepts
+    model = self.root.find('RegressionModel')
+
+    if model is None:
+      raise Exception('PMML model does not contain RegressionModel.')
+
+    tables = [
+      table for table in model.findall('RegressionTable')
+      if table.find('NumericPredictor') is not None
+    ]
+
+    self.coef_ = [
+      _linear_get_coefficients(self, table)
+      for table in tables
+    ]
+    self.intercept_ = [
+      float(table.get('intercept'))
+      for table in tables
+    ]
+
+    if len(self.coef_) == 1:
+      self.coef_ = [self.coef_[0]]
+
+    if len(self.intercept_) == 1:
+      self.intercept_ = [self.intercept_[0]]
+
+    self.coef_ = np.array(self.coef_)
+    self.intercept_ = np.array(self.intercept_)
+
+  def fit(self, x, y):
+    return PMMLBaseClassifier.fit(self, x, y)
+
+  def _more_tags(self):
+    return LinearSVC._more_tags(self)
+
+
+class PMMLLinearSVR(OneHotEncodingMixin, PMMLBaseRegressor, LinearSVR):
+  """
+  Linear Support Vector Regression.
+
+  Similar to SVR with parameter kernel='linear', but implemented in terms of
+  liblinear rather than libsvm, so it has more flexibility in the choice of
+  penalties and loss functions and should scale better to large numbers of
+  samples.
+
+  This class supports both dense and sparse input.
+
+  The PMML model is assumed to be equivalent to PMMLLinearRegression.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/Regression.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseRegressor.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+
+    # Import coefficients and intercepts
+    model = self.root.find('RegressionModel')
+
+    if model is None:
+      raise Exception('PMML model does not contain RegressionModel.')
+
+    tables = model.findall('RegressionTable')
+
+    self.coef_ = np.array([
+      _linear_get_coefficients(self, table)
+      for table in tables
+    ])
+    self.intercept_ = np.array([
+      float(table.get('intercept'))
+      for table in tables
+    ])
+
+    if self.coef_.shape[0] == 1:
+      self.coef_ = self.coef_[0]
+
+    if self.intercept_.shape[0] == 1:
+      self.intercept_ = self.intercept_[0]
+
+  def fit(self, x, y):
+    return PMMLBaseRegressor.fit(self, x, y)
+
+  def _more_tags(self):
+    return LinearSVR._more_tags(self)
+
+
+class PMMLNuSVC(OneHotEncodingMixin, PMMLBaseClassifier, PMMLBaseSVM, NuSVC):
+  """
+  Nu-Support Vector Classification.
+
+  Similar to SVC but uses a parameter to control the number of support
+  vectors.
+
+  The implementation is based on libsvm.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/SupportVectorMachine.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseClassifier.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+    NuSVC.__init__(self)
+    PMMLBaseSVM.__init__(self)
+
+  def _prepare_data(self, X):
+    self._sparse = isspmatrix(X)
+    return super()._prepare_data(X)
+
+  def decision_function(self, X, *args, **kwargs):
+    X = self._prepare_data(X)
+    return super().decision_function(X, *args, **kwargs)
+
+  def fit(self, x, y):
+    return PMMLBaseClassifier.fit(self, x, y)
+
+  def _more_tags(self):
+    return NuSVC._more_tags(self)
+
+
+class PMMLNuSVR(OneHotEncodingMixin, PMMLBaseRegressor, PMMLBaseSVM, NuSVR):
+  """
+  Nu Support Vector Regression.
+
+  Similar to NuSVC, for regression, uses a parameter nu to control
+  the number of support vectors. However, unlike NuSVC, where nu
+  replaces C, here nu replaces the parameter epsilon of epsilon-SVR.
+
+  The implementation is based on libsvm.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/SupportVectorMachine.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseRegressor.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+    NuSVR.__init__(self)
+    PMMLBaseSVM.__init__(self)
+
+  def _prepare_data(self, X):
+    self._sparse = isspmatrix(X)
+    return super()._prepare_data(X)
+
+  def fit(self, x, y):
+    return PMMLBaseRegressor.fit(self, x, y)
+
+  def _more_tags(self):
+    return NuSVR._more_tags(self)
+
+
+class PMMLSVC(OneHotEncodingMixin, PMMLBaseClassifier, PMMLBaseSVM, SVC):
+  """
+  C-Support Vector Classification.
+
+  The implementation is based on libsvm. The multiclass support is
+  handled according to a one-vs-one scheme.
+
+  For details on the precise mathematical formulation of the provided
+  kernel functions and how `gamma`, `coef0` and `degree` affect each
+  other, see the corresponding section in the narrative documentation:
+  `Kernel functions <https://scikit-learn.org/stable/modules/svm.html#svm-kernels>`_.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/SupportVectorMachine.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseClassifier.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+    SVC.__init__(self)
+    PMMLBaseSVM.__init__(self)
+
+  def _prepare_data(self, X):
+    self._sparse = isspmatrix(X)
+    return super()._prepare_data(X)
+
+  def decision_function(self, X, *args, **kwargs):
+    X = self._prepare_data(X)
+    return super().decision_function(X, *args, **kwargs)
+
+  def fit(self, x, y):
+    return PMMLBaseClassifier.fit(self, x, y)
+
+  def _more_tags(self):
+    return SVC._more_tags(self)
+
+
+class PMMLSVR(OneHotEncodingMixin, PMMLBaseRegressor, PMMLBaseSVM, SVR):
+  """
+  Epsilon-Support Vector Regression.
+
+  The free parameters in the model are C and epsilon. The implementation
+  is based on libsvm.
+
+  For details on the precise mathematical formulation of the provided
+  kernel functions and how `gamma`, `coef0` and `degree` affect each
+  other, see the corresponding section in the narrative documentation:
+  `Kernel functions <https://scikit-learn.org/stable/modules/svm.html#svm-kernels>`_.
+
+  Parameters
+  ----------
+  pmml : str, object
+    Filename or file object containing PMML data.
+
+  Notes
+  -----
+  Specification: http://dmg.org/pmml/v4-3/SupportVectorMachine.html
+
+  """
+  def __init__(self, pmml):
+    PMMLBaseRegressor.__init__(self, pmml)
+    OneHotEncodingMixin.__init__(self)
+    SVR.__init__(self)
+    PMMLBaseSVM.__init__(self)
+
+  def _prepare_data(self, X):
+    self._sparse = isspmatrix(X)
+    return super()._prepare_data(X)
+
+  def fit(self, x, y):
+    return PMMLBaseRegressor.fit(self, x, y)
+
+  def _more_tags(self):
+    return SVR._more_tags(self)

--- a/sklearn_pmml_model/tree/tree.py
+++ b/sklearn_pmml_model/tree/tree.py
@@ -1,8 +1,7 @@
 import numpy as np
 import struct
-import re
 from sklearn.base import clone as _clone
-from sklearn_pmml_model.base import PMMLBaseClassifier, PMMLBaseRegressor
+from sklearn_pmml_model.base import PMMLBaseClassifier, PMMLBaseRegressor, parse_array
 from sklearn_pmml_model.tree._tree import Tree, NODE_DTYPE, TREE_LEAF, TREE_UNDEFINED
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn_pmml_model.datatypes import Category
@@ -11,7 +10,6 @@ from warnings import warn
 from xml.etree import cElementTree as eTree
 
 SPLIT_UNDEFINED = struct.pack('d', TREE_UNDEFINED)
-cat_regex = re.compile(r"""('.*?'|".*?"|\S+)""")
 
 
 class PMMLTreeClassifier(PMMLBaseClassifier, DecisionTreeClassifier):
@@ -317,10 +315,7 @@ def construct_tree(node, classes, field_mapping, i=0, rescale_factor=1):
       column, field_type = field_mapping[set_predicate.get('field')]
 
       array = set_predicate.find('Array')
-      categories = [
-        x.replace('"', '').replace('▲', '"')
-        for x in cat_regex.findall(array.text.replace('\\"', '▲'))
-      ]
+      categories = parse_array(array)
 
       mask = 0
 

--- a/tests/svm/test_svm.py
+++ b/tests/svm/test_svm.py
@@ -1,0 +1,459 @@
+from unittest import TestCase
+import sklearn_pmml_model
+from sklearn.svm import LinearSVC, LinearSVR, NuSVC, NuSVR, SVC, SVR
+from sklearn_pmml_model.svm import PMMLLinearSVC, PMMLLinearSVR, PMMLNuSVC, PMMLNuSVR, PMMLSVC, PMMLSVR
+import pandas as pd
+import numpy as np
+from os import path, remove
+from io import StringIO
+from sklearn2pmml.pipeline import PMMLPipeline
+from sklearn2pmml import sklearn2pmml
+
+BASE_DIR = path.dirname(sklearn_pmml_model.__file__)
+
+
+class TestBaseSVR(TestCase):
+    def test_invalid_model(self):
+        with self.assertRaises(Exception) as cm:
+            PMMLSVC(pmml=StringIO("""
+              <PMML xmlns="http://www.dmg.org/PMML-4_3" version="4.3">
+                <DataDictionary>
+                  <DataField name="Class" optype="categorical" dataType="string">
+                    <Value value="setosa"/>
+                    <Value value="versicolor"/>
+                    <Value value="virginica"/>
+                  </DataField>
+                </DataDictionary>
+                <MiningSchema>
+                  <MiningField name="Class" usageType="target"/>
+                </MiningSchema>
+              </PMML>
+              """))
+
+        assert str(cm.exception) == 'PMML model does not contain SupportVectorMachineModel.'
+
+
+class TestLinearSVRIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/linear-model-lm.pmml')
+        self.clf = PMMLLinearSVR(pmml)
+
+        self.ref = LinearSVR()
+        self.ref.fit(Xenc, yte == 'Yes')
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == LinearSVR()._more_tags()
+
+    def test_sklearn2pmml(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svm-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLLinearSVR(pmml='svm-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svm-sklearn2pmml.pmml")
+
+
+class TestLinearSVCIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/linear-model-lmc.pmml')
+        self.clf = PMMLLinearSVC(pmml)
+
+        self.ref = LinearSVC()
+        self.ref.fit(Xenc, yte)
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == LinearSVC()._more_tags()
+
+    def test_sklearn2pmml(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svm-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLLinearSVC(pmml='svm-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svm-sklearn2pmml.pmml")
+
+
+class TestSVRIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/svr-cat-pima.pmml')
+        self.clf = PMMLSVR(pmml)
+
+        self.ref_rbf = SVR(kernel='rbf')
+        self.ref_rbf.fit(Xenc, yte == 'Yes')
+        self.ref_linear = SVR(kernel='linear')
+        self.ref_linear.fit(Xenc, yte == 'Yes')
+        self.ref_poly = SVR(kernel='poly')
+        self.ref_poly.fit(Xenc, yte == 'Yes')
+        self.ref_sigmoid = SVR(kernel='sigmoid')
+        self.ref_sigmoid.fit(Xenc, yte == 'Yes')
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == SVR()._more_tags()
+
+    def test_sklearn2pmml_rbf(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("regressor", self.ref_rbf)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svr-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVR(pmml='svr-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_rbf.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svr-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_linear(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("regressor", self.ref_linear)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svr-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVR(pmml='svr-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_linear.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svr-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_poly(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("regressor", self.ref_poly)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svr-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVR(pmml='svr-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_poly.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svr-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_sigmoid(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("regressor", self.ref_sigmoid)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svr-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVR(pmml='svr-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_sigmoid.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svr-sklearn2pmml.pmml")
+
+
+class TestSVCIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/svc-cat-pima.pmml')
+        self.clf = PMMLSVC(pmml)
+
+        self.ref_rbf = SVC(kernel='rbf')
+        self.ref_rbf.fit(Xenc, yte)
+        self.ref_linear = SVC(kernel='linear')
+        self.ref_linear.fit(Xenc, yte)
+        self.ref_poly = SVC(kernel='poly')
+        self.ref_poly.fit(Xenc, yte)
+        self.ref_sigmoid = SVC(kernel='sigmoid')
+        self.ref_sigmoid.fit(Xenc, yte)
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == SVC()._more_tags()
+
+    def test_sklearn2pmml_rbf(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref_rbf)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1])
+        sklearn2pmml(pipeline, "svc-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVC(pmml='svc-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_rbf.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svc-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_linear(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref_linear)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1])
+        sklearn2pmml(pipeline, "svc-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVC(pmml='svc-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_linear.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svc-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_poly(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref_poly)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1])
+        sklearn2pmml(pipeline, "svc-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVC(pmml='svc-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_poly.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svc-sklearn2pmml.pmml")
+
+    def test_sklearn2pmml_sigmoid(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref_sigmoid)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1])
+        sklearn2pmml(pipeline, "svc-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLSVC(pmml='svc-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref_sigmoid.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svc-sklearn2pmml.pmml")
+
+
+class TestNuSVRIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/svr-cat-pima.pmml')
+        self.clf = PMMLNuSVR(pmml)
+
+        self.ref = NuSVR()
+        self.ref.fit(Xenc, yte == 'Yes')
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == NuSVR()._more_tags()
+
+    def test_sklearn2pmml(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("regressor", self.ref)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1] == 'Yes')
+        sklearn2pmml(pipeline, "svr-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLNuSVR(pmml='svr-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref.predict(Xenc),
+                model.predict(Xenc)
+            )
+
+        finally:
+            remove("svr-sklearn2pmml.pmml")
+
+
+class TestNuSVCIntegration(TestCase):
+    def setUp(self):
+        df = pd.read_csv(path.join(BASE_DIR, '../models/categorical-test.csv'))
+        Xte = df.iloc[:, 1:]
+        Xenc = pd.get_dummies(Xte, prefix_sep='')
+        yte = df.iloc[:, 0]
+        self.test = (Xte, yte)
+        self.enc = (Xenc, yte)
+
+        pmml = path.join(BASE_DIR, '../models/svc-cat-pima.pmml')
+        self.clf = PMMLNuSVC(pmml)
+
+        self.ref = NuSVC()
+        self.ref.fit(Xenc, yte)
+
+    def test_fit_exception(self):
+        with self.assertRaises(Exception) as cm:
+            self.clf.fit(np.array([[]]), np.array([]))
+
+        assert str(cm.exception) == 'Not supported.'
+
+    def test_more_tags(self):
+        assert self.clf._more_tags() == NuSVC()._more_tags()
+
+    def test_sklearn2pmml(self):
+        # Export to PMML
+        pipeline = PMMLPipeline([
+            ("classifier", self.ref)
+        ])
+        pipeline.fit(self.enc[0], self.enc[1])
+        sklearn2pmml(pipeline, "svc-sklearn2pmml.pmml", with_repr=True)
+
+        try:
+            # Import PMML
+            model = PMMLNuSVC(pmml='svc-sklearn2pmml.pmml')
+
+            # Verify classification
+            Xenc, _ = self.enc
+            assert np.allclose(
+                self.ref.decision_function(Xenc),
+                model.decision_function(Xenc)
+            )
+
+        finally:
+            remove("svc-sklearn2pmml.pmml")


### PR DESCRIPTION
This PR adds support for Support Vector Machines. Radial-basis, linear, polynomial and sigmoid kernels are all supported.  Categorical support is implemented by one hot encoding features, just like done for linear models. Results are consistent with sklearn2pmml models, as the integration tests reflect. PMML models from R with `svm` from the `e1071` library have embedded feature scaling, for which we will add support in a follow-up PR shortly.