### PR TITLE
Support major release of scikit-learn 1.x

### DIFF
--- a/sklearn_pmml_model/base.py
+++ b/sklearn_pmml_model/base.py
@@ -6,6 +6,7 @@ from sklearn.compose import ColumnTransformer
 from xml.etree import cElementTree as eTree
 from cached_property import cached_property
 from sklearn_pmml_model.datatypes import Category
+from sklearn.utils.multiclass import type_of_target
 from collections import OrderedDict
 import datetime
 import re
@@ -270,6 +271,7 @@ class PMMLBaseClassifier(PMMLBaseEstimator):
     except AttributeError:
       self._label_binarizer = LabelBinarizer(pos_label=1, neg_label=-1)
       self._label_binarizer.classes_ = np.array(target_type.categories)
+      self._label_binarizer.y_type_ = type_of_target(target_type.categories)
     self.n_classes_ = len(self.classes_)
     self.n_outputs_ = 1
 

--- a/sklearn_pmml_model/base.py
+++ b/sklearn_pmml_model/base.py
@@ -36,7 +36,10 @@ class PMMLBaseEstimator(BaseEstimator):
       el.tag = el.tag[ns_offset:]  # strip all namespaces
     self.root = it.root
 
-    self.n_features_ = len([0 for e in self.fields.values() if e.tag == 'DataField']) - 1
+    try:
+      self.n_features_ = len([0 for e in self.fields.values() if e.tag == 'DataField']) - 1
+    except AttributeError:
+      self.n_features_in_ = len([0 for e in self.fields.values() if e.tag == 'DataField']) - 1
 
   @cached_property
   def field_mapping(self):

--- a/sklearn_pmml_model/ensemble/_gradient_boosting.pyx
+++ b/sklearn_pmml_model/ensemble/_gradient_boosting.pyx
@@ -35,7 +35,6 @@ ctypedef np.uint8_t uint8
 # no namespace lookup for numpy dtype and array creation
 from numpy import zeros as np_zeros
 from numpy import ones as np_ones
-from numpy import bool as np_bool
 from numpy import float32 as np_float32
 from numpy import float64 as np_float64
 
@@ -417,7 +416,7 @@ def _random_sample_mask(np.npy_intp n_total_samples,
      cdef np.ndarray[float64, ndim=1, mode="c"] rand = \
           random_state.rand(n_total_samples)
      cdef np.ndarray[uint8, ndim=1, mode="c", cast=True] sample_mask = \
-          np_zeros((n_total_samples,), dtype=np_bool)
+          np_zeros((n_total_samples,), dtype=bool)
 
      cdef np.npy_intp n_bagged = 0
      cdef np.npy_intp i = 0

--- a/sklearn_pmml_model/ensemble/forest.py
+++ b/sklearn_pmml_model/ensemble/forest.py
@@ -65,7 +65,10 @@ class PMMLForestClassifier(IntegerEncodingMixin, PMMLBaseClassifier, RandomFores
 
     clf = self._make_estimator(append=False, random_state=123)
     clf.classes_ = self.classes_
-    clf.n_features_ = self.n_features_
+    try:
+      clf.n_features_in_ = self.n_features_in_
+    except AttributeError:
+      clf.n_features_ = self.n_features_
     clf.n_outputs_ = self.n_outputs_
     clf.n_classes_ = self.n_classes_
     self.template_estimator = clf
@@ -154,7 +157,10 @@ class PMMLForestRegressor(IntegerEncodingMixin, PMMLBaseRegressor, RandomForestR
     self._validate_estimator()
 
     clf = self._make_estimator(append=False, random_state=123)
-    clf.n_features_ = self.n_features_
+    try:
+      clf.n_features_in_ = self.n_features_in_
+    except AttributeError:
+      clf.n_features_ = self.n_features_
     clf.n_outputs_ = self.n_outputs_
     self.template_estimator = clf
 

--- a/sklearn_pmml_model/ensemble/gb.py
+++ b/sklearn_pmml_model/ensemble/gb.py
@@ -70,7 +70,10 @@ class PMMLGradientBoostingClassifier(IntegerEncodingMixin, PMMLBaseClassifier, G
     GradientBoostingClassifier.__init__(self, n_estimators=n_estimators)
 
     clf = DecisionTreeRegressor(random_state=123)
-    clf.n_features_ = self.n_features_
+    try:
+      clf.n_features_in_ = self.n_features_in_
+    except AttributeError:
+      clf.n_features_ = self.n_features_
     clf.n_outputs_ = self.n_outputs_
     self.template_estimator = clf
 
@@ -189,7 +192,10 @@ class PMMLGradientBoostingRegressor(IntegerEncodingMixin, PMMLBaseRegressor, Gra
     GradientBoostingRegressor.__init__(self, n_estimators=n_estimators)
 
     clf = DecisionTreeRegressor(random_state=123)
-    clf.n_features_ = self.n_features_
+    try:
+      clf.n_features_in_ = self.n_features_in_
+    except AttributeError:
+      clf.n_features_ = self.n_features_
     clf.n_outputs_ = self.n_outputs_
     self.template_estimator = clf
 

--- a/sklearn_pmml_model/linear_model/implementations.py
+++ b/sklearn_pmml_model/linear_model/implementations.py
@@ -84,6 +84,7 @@ class PMMLLogisticRegression(OneHotEncodingMixin, PMMLBaseClassifier, LogisticRe
   def __init__(self, pmml):
     PMMLBaseClassifier.__init__(self, pmml)
     OneHotEncodingMixin.__init__(self)
+    LogisticRegression.__init__(self)
 
     # Import coefficients and intercepts
     model = self.root.find('RegressionModel')

--- a/sklearn_pmml_model/naive_bayes/implementations.py
+++ b/sklearn_pmml_model/naive_bayes/implementations.py
@@ -54,10 +54,16 @@ class PMMLGaussianNB(OneHotEncodingMixin, PMMLBaseClassifier, GaussianNB):
       [float(value.get('mean', 0)) for value in target_values[target]]
       for target in self.classes_
     ])
-    self.sigma_ = np.array([
-      [float(value.get('variance', 0)) for value in target_values[target]]
-      for target in self.classes_
-    ])
+    try:
+      self.sigma_ = np.array([
+        [float(value.get('variance', 0)) for value in target_values[target]]
+        for target in self.classes_
+      ])
+    except AttributeError:
+      self.var_ = np.array([
+        [float(value.get('variance', 0)) for value in target_values[target]]
+        for target in self.classes_
+      ])
 
   def _get_target_values(self, inputs, target):
     def target_value_for_category(bayesInput, category):

--- a/sklearn_pmml_model/svm/_base.py
+++ b/sklearn_pmml_model/svm/_base.py
@@ -1,6 +1,6 @@
 # License: BSD 2-Clause
 
-from sklearn_pmml_model.base import PMMLBaseRegressor, parse_array
+from sklearn_pmml_model.base import PMMLBaseRegressor, PMMLBaseClassifier, parse_array
 import numpy as np
 
 
@@ -61,7 +61,7 @@ class PMMLBaseSVM:
       get_coefficients(classes, self._n_support, self.support_, svms)
     )
 
-    if len(classes) == 2:
+    if isinstance(self, PMMLBaseClassifier) and len(classes) == 2:
       self._n_support = (self._n_support / 2).astype(np.int32)
 
     linear = model.find('LinearKernelType')

--- a/sklearn_pmml_model/svm/_classes.py
+++ b/sklearn_pmml_model/svm/_classes.py
@@ -36,6 +36,7 @@ class PMMLLinearSVC(OneHotEncodingMixin, PMMLBaseClassifier, LinearSVC):
   def __init__(self, pmml):
     PMMLBaseClassifier.__init__(self, pmml)
     OneHotEncodingMixin.__init__(self)
+    LinearSVC.__init__(self)
 
     # Import coefficients and intercepts
     model = self.root.find('RegressionModel')

--- a/sklearn_pmml_model/tree/tree.py
+++ b/sklearn_pmml_model/tree/tree.py
@@ -43,8 +43,12 @@ class PMMLTreeClassifier(PMMLBaseClassifier, DecisionTreeClassifier):
       raise Exception('PMML model does not contain TreeModel.')
 
     # Parse tree
-    self.tree_ = Tree(self.n_features_, np.array([self.n_classes_], dtype=np.intp),
-                      self.n_outputs_, np.array([], dtype=np.int32))
+    try:
+      self.tree_ = Tree(self.n_features_in_, np.array([self.n_classes_], dtype=np.intp),
+                        self.n_outputs_, np.array([], dtype=np.int32))
+    except AttributeError:
+      self.tree_ = Tree(self.n_features_, np.array([self.n_classes_], dtype=np.intp),
+                        self.n_outputs_, np.array([], dtype=np.int32))
 
     split = tree_model.get('splitCharacteristic')
     if split == 'binarySplit':
@@ -117,8 +121,12 @@ class PMMLTreeRegressor(PMMLBaseRegressor, DecisionTreeRegressor):
     # Parse tree
     self.n_outputs_ = 1
     n_classes = np.array([1] * self.n_outputs_, dtype=np.intp)
-    self.tree_ = Tree(self.n_features_, n_classes, self.n_outputs_,
-                      np.array([], dtype=np.int32))
+    try:
+      self.tree_ = Tree(self.n_features_in_, n_classes, self.n_outputs_,
+                        np.array([], dtype=np.int32))
+    except AttributeError:
+      self.tree_ = Tree(self.n_features_, n_classes, self.n_outputs_,
+                        np.array([], dtype=np.int32))
 
     split = tree_model.get('splitCharacteristic')
     if split == 'binarySplit':
@@ -425,7 +433,10 @@ def clone(est, safe=True):
 
   """
   new_object = _clone(est, safe=safe)
-  new_object.n_features_ = est.n_features_
+  try:
+    new_object.n_features_in_ = est.n_features_in_
+  except AttributeError:
+    new_object.n_features_ = est.n_features_
   new_object.n_outputs_ = est.n_outputs_
 
   if isinstance(est, DecisionTreeClassifier):
@@ -433,11 +444,19 @@ def clone(est, safe=True):
     new_object.n_classes_ = est.n_classes_
     n_classes = np.asarray([est.n_classes_], dtype=np.intp)
 
-    new_object.tree_ = Tree(est.n_features_, n_classes, est.n_outputs_,
-                            np.array([], dtype=np.int32))
+    try:
+      new_object.tree_ = Tree(est.n_features_in_, n_classes, est.n_outputs_,
+                              np.array([], dtype=np.int32))
+    except AttributeError:
+      new_object.tree_ = Tree(est.n_features_, n_classes, est.n_outputs_,
+                              np.array([], dtype=np.int32))
   else:
     n_classes = np.array([1] * est.n_outputs_, dtype=np.intp)
-    new_object.tree_ = Tree(est.n_features_, n_classes, est.n_outputs_,
-                            np.array([], dtype=np.int32))
+    try:
+      new_object.tree_ = Tree(est.n_features_in_, n_classes, est.n_outputs_,
+                              np.array([], dtype=np.int32))
+    except AttributeError:
+      new_object.tree_ = Tree(est.n_features_, n_classes, est.n_outputs_,
+                              np.array([], dtype=np.int32))
 
   return new_object

--- a/tests/ensemble/test_forest.py
+++ b/tests/ensemble/test_forest.py
@@ -103,7 +103,7 @@ class TestForest(TestCase):
         </MiningModel>
       </PMML>
       """))
-    assert len(w) == 1
+    assert len([w for w in w if not isinstance(w.message, FutureWarning)]) == 1
 
   def test_fit_exception(self):
     with self.assertRaises(Exception) as cm:
@@ -191,7 +191,7 @@ class TestForestRegression(TestCase):
         </MiningModel>
       </PMML>
       """))
-        assert len(w) == 1
+        assert len([w for w in w if not isinstance(w.message, FutureWarning)]) == 1
 
     def test_fit_exception(self):
         with self.assertRaises(Exception) as cm:


### PR DESCRIPTION
Since `scikit-learn` officially released 1.0 the API has changed a bit. Mostly renaming, but sufficient for breaking `sklearn-pmml-model`. This PR resolves those issues while staying compatible with previous (recent) 0.x versions