### PR TITLE
Improvements to estimator auto detect

### DIFF
--- a/sklearn_pmml_model/auto_detect/base.py
+++ b/sklearn_pmml_model/auto_detect/base.py
@@ -23,6 +23,9 @@ def auto_detect_estimator(pmml, **kwargs):
       Filename or file object containing PMML data.
 
   """
+  if isinstance(pmml, io.IOBase) and not pmml.seekable():
+    pmml = io.StringIO(pmml.read())
+
   base = PMMLBaseEstimator(pmml=pmml)
   target_field_name = base.target_field.attrib['name']
   target_field_type = base.field_mapping[target_field_name][1]


### PR DESCRIPTION
This PR fixes an issue for loading file-like objects (file could be closed before completing the import), and adds support for non-seekable file-like objects. I assumed `seek` would be universally supported but it turns out that is not the case.